### PR TITLE
Added missing links to index.html

### DIFF
--- a/slice/index.html
+++ b/slice/index.html
@@ -94,7 +94,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	<div class="row"><div class="col-md-12">
 		<h4>Dependency Injection with Google Guice</h4>
 		<p>If your AEM components are more than simple text/image/title components (and they certainly are), then you probably need to combine their functionality with some external data or more complex business logic provided by other classes. Dependency injection allows you to do this easily and keep your code testable without boiler-plate code and unneeded arguments in methods used only to propagate a value down into the class hierarchy.</p>
-		<p>We took Guice as a DI container. Why it's awesome? Take a look here: Google I/O 2009 - Big Modular Java with Guice, and here to check motivation of Google Guice creators</p>
+		<p>We took Guice as a DI container. Why it's awesome? Take a look here: <a href="https://www.youtube.com/watch?v=hBVJbzAagfs" title="Bob Lee's Google I/O 2009 presentation about Guice">Google I/O 2009 - Big Modular Java with Guice</a>, and <a href="https://github.com/google/guice/wiki/Motivation" title="Motivation behind Google Guice">here</a> to check motivation of Google Guice creators</p>
 		<div class="button-more bottom-link"><a href="/slice/documentation.html" title="Slice Documentation">Discover all features!</a></div>
 	</div>
 	</div>


### PR DESCRIPTION
The text on index.html indicated that there were supposed to be links to a Google I/O presentation and the _Motivation_ page on the Google Guice Github page.

Found the links and added them here.