### PR TITLE
Connect 2015 is now history, description amended

### DIFF
--- a/aem-rules-for-sonarqube/index.html
+++ b/aem-rules-for-sonarqube/index.html
@@ -54,12 +54,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     
     <div style="background-color: #f6f6f6; border-left: 3px solid #a0ce4e" class="top-container">
         <div style="margin-left: 15px; font-size:  1.6rem; color: #747474; padding: 15px;">
-            <p>What is AEM Rules for SonarQube? It is a set of rules in a form of a SonarQube plugin detecting possible bugs and bad smells specific for AEM development in our code. Plugin will be presented for the first time on Connect Web Experience conference in Basel 2015.</p>
+            <p>What is <strong>AEM Rules</strong> for SonarQube? It is a set of rules in a form of a SonarQube plugin detecting possible bugs and bad smells specific for AEM development in our code. The plugin was presented for the first time at the <strong>Connect Web Experience</strong> conference in Basel 2015. The slides are available for download <a href="assets/AEM_Rules%20_Connect2015.pdf">here</a>.</p>
         </div>
     </div>
     <div class="col-md-6">
     <h3>Purpose</h3>
-    <p>As we all know, SonarQube is a great tool that helps us increase quality of our codebase. However, it does apply mainly to general Java issues. As we know, we can hurt ourselves much more doing AEM. This tool is intended to find common bugs and bad smells specific for AEM development. Documentation of each rule is available from SonarQube interface after plugin installation.<p>
+    <p>As we all know, <a href="http://www.sonarqube.org/" title="SonarQube homepage">SonarQube</a> is a great tool that helps us improve the quality of our codebase. However, it does apply mainly to general Java issues. As we know, we can hurt ourselves much more doing AEM. This tool is intended to find common bugs and bad smells specific for AEM development. Documentation of each rule is available from SonarQube interface after plugin installation.<p>
     
     </div><div class="col-md-6">
     <h3>How to get it?</h3>


### PR DESCRIPTION
Just stumbled upon this description and found it quite obviously out of date.
- Changed the description of the presentation given about the plugin as the conference has already happened.
- Added a link to the previously uploaded presentation deck (not sure why this wasn't done when the slides were originally uploaded, **anything stopping us from publishing them?**)
- Added a link to the SonarQube home page