### PR TITLE
fixed twitter on safari and changed to cognifide channel

### DIFF
--- a/css/cognifide.github.css
+++ b/css/cognifide.github.css
@@ -6,13 +6,18 @@
     -webkit-flex-wrap: wrap;
     flex-wrap: wrap;
 }
+.row:before,
+.row:after {
+    display: initial;
+    content: unset;
+}
 /* Medium devices (desktops, 992px and up) */
 @media (min-width: 992px) {
     .col-md-4 {
         width: 33.3%;
         height: 485px;
     }
-    
+
     #footer .col-md-4 {
         height: auto;
     }
@@ -355,7 +360,7 @@
             to bottom,
             rgba(0, 0, 0, 0),
             rgba(0, 0, 0, 0.5)
-    ), 
+    ),
     url(../images/labs-banner.jpg);
     width: 100%;
     height: 380px;
@@ -454,3 +459,6 @@ h4 {
   margin-bottom: 30px;
  }
 
+.twitter-timeline {
+    height: 440px !important; /* Necessary because twitter script makes it 600px high */
+}

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -3,7 +3,7 @@
 		<div class="row text-center" style="color: #edebeb; margin-top: 40px; margin-bottom: 40px;">
 			<div class="col-md-4" style="font-size: 22px;">
 				<a href="https://github.com/cognifide" class="fa fa-github social github-icon" target="_blank"> </a>
-				<a href="https://twitter.com/CognifideLabs" class="fa fa-twitter social twitter-icon" target="_blank"> </a>
+				<a href="https://twitter.com/cognifide" class="fa fa-twitter social twitter-icon" target="_blank"> </a>
 				<a href="https://www.linkedin.com/company/cognifide" class="fa fa-linkedin social linkedin-icon" target="_blank"> </a>
 				<a href="https://www.facebook.com/cognifide/" class="fa fa-facebook social facebook-icon" target="_blank"> </a>
 				<a href="https://www.youtube.com/user/Cognifide?sub_confirmation=1" class="fa fa-youtube social youtube-icon" target="_blank"> </a>

--- a/index.html
+++ b/index.html
@@ -67,15 +67,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		</div>
 		<div class="col-md-4">
 				<h3>Follow us on Twitter</h3>
-				<a class="twitter-timeline"  href="https://twitter.com/CognifideLabs" data-widget-id="620941964838588416">Tweets by @CognifideLabs</a>
+				<a class="twitter-timeline"  href="https://twitter.com/cognifide" data-widget-id="620941964838588416">Tweets by @cognifide</a>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-		</div> 
+		</div>
 	</div>
 	<hr>
 	<div class="row">
 		<div class="col-md-12">
-			<h2>Check our solutions!</h2> 
-		</div>   
+			<h2>Check our solutions!</h2>
+		</div>
 		<div class="col-md-4">
 			<div class="component promo highlighted-top indent-top">
 				<div class="component-content">
@@ -128,7 +128,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 				</div>
 			</div>
 		</div>
-		
+
 		<div class="col-md-4">
 			<div class="component promo highlighted-top indent-top">
 				<div class="component-content">


### PR DESCRIPTION
Changes made according to Albert Cenkier's request:
> - (high) przestawic twittera na ogolny kanal #cognifide (https://twitter.com/cognifide)
> - (medium) poprawić błedy w wyswietlaniu na safari - https://www.dropbox.com/s/kumjoz0xk2tpiln/Screenshot%202019-01-16%2014.53.43.png?dl=0